### PR TITLE
Combine Windows and Linux in the same repo (several fixes)

### DIFF
--- a/src/common/commonSteps.ts
+++ b/src/common/commonSteps.ts
@@ -279,17 +279,16 @@ async function installExtensionForCommand(page: Page, extensionDir: string) {
   await screenShot.screenShot("start_install_extension.png")
   await page.keyboard.press("Enter")
   await sleep(8)
-  if (os.platform() === "win32"){
-    await retry(
-      2,
-      async () => {
-        const installed = page.locator('.codicon-terminal-decoration-success')
-        return (await installed.count()) > 0
-      },
-      `Failed to install the extension.`,
-      1
-    )
-  }
+  await retry(
+    8,
+    async () => {
+      const installed = page.locator('.codicon-terminal-decoration-success')
+      return (await installed.count()) > 0
+    },
+    `Failed to install the extension.`,
+    1
+  )
+
   await screenShot.screenShot("start_install_extension_result.png")
 }
 

--- a/src/common/commonSteps.ts
+++ b/src/common/commonSteps.ts
@@ -125,27 +125,16 @@ async function startWithRightClick(page: Page, command: string, type?: string) {
  */
 async function selectFolder(file: string = "") {
   await sleep(10)
-  if (os.platform() === "win32") {
-    if (file) {
-      if (!process.env.CI) {
-        await keyboard.pressKey(Key.CapsLock)
-      }
-      await keyboard.type(file)
-      if (file.includes("CreateTypespecProject")) {
-        await sleep(2)
-        await keyboard.pressKey(Key.Enter)
-      }
-    }
-    await screenShot.screenShot("select_folder.png")
+  await keyboard.type(file)
+  if (os.platform() === "win32" 
+    && file.includes("CreateTypespecProject")
+  ) {
+    await sleep(2)
     await keyboard.pressKey(Key.Enter)
-  } else {
-    if (file == "openapi.3.0.yaml" || file == "ImportTypespecProjectEmptyFolder") {
-      await keyboard.pressKey(Key.Down)
-      await sleep(3)
-    }
-    await keyboard.type(file)
-    await screenShot.screenShot("select_folder.png")
-    await keyboard.pressKey(Key.Enter)
+  }
+  await screenShot.screenShot("select_folder.png")
+  await keyboard.pressKey(Key.Enter)
+  if (os.platform() !== "win32") {
     await keyboard.releaseKey(Key.Enter)
   }
 }

--- a/src/common/downloadSetup.ts
+++ b/src/common/downloadSetup.ts
@@ -9,16 +9,9 @@ export default async function downloadVscode({ provide }: GlobalSetupContext) {
   if (process.platform.includes("win")){
     const version = "1.100.2";
     const platform = "win32-x64-archive";
-
-    if (process.env.VSCODE_E2E_DOWNLOAD_PATH) {
-      provide("executablePath", process.env.VSCODE_E2E_DOWNLOAD_PATH);
-    } else {
-      provide("executablePath", await download({ version, platform }));
-    }
+    provide("executablePath", await download({ version, platform }));
   } else {
-    if (process.env.VSCODE_E2E_DOWNLOAD_PATH)
-      provide("executablePath", process.env.VSCODE_E2E_DOWNLOAD_PATH)
-    else provide("executablePath", await download())
+    provide("executablePath", await download())
   }
 }
 

--- a/windows-tests-stage.yml
+++ b/windows-tests-stage.yml
@@ -56,14 +56,14 @@ jobs:
         displayName: "Install dependencies"
 
       - script: |
-          set JAVA_HOME=%JAVA_HOME_21_X64%
-          set PATH=%JAVA_HOME%\bin;%PATH%
           echo "Running Emit Test Cases"
           npm run test:emit
         displayName: "Run Emit Test Cases"
         env:
           BUILD_ARTIFACT_STAGING_DIRECTORY: $(Build.ArtifactStagingDirectory)
           CI: true
+          JAVA_HOME: $(JAVA_HOME_21_X64)
+          PATH: $(JAVA_HOME_21_X64)\bin;$(PATH)
         continueOnError: true
 
       - task: PublishBuildArtifacts@1


### PR DESCRIPTION
- Optimized the selectFolder method in Linux.
- Fixed “Only throw the exception 'failed install extension' for Linux”.
- Deleted unnecessary if-else structure.
- Set up a long-term solution for setting Java environment when in Pipelines Windows.