### PR TITLE
Set runLinux to default true

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,7 +16,7 @@ parameters:
   - name: runLinux
     displayName: 'Run Linux UI Tests'
     type: boolean
-    default: false
+    default: true
 
 stages:
   - stage: WindowsTests


### PR DESCRIPTION
- Set runLinux to default true. Now pipelines run Windows and Linux versions by default.